### PR TITLE
Place all nodes in an arena of sorts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use std::{iter::FromIterator, mem::size_of, ops::Deref, ops::DerefMut};
 )]
 pub struct HexSet {
     /// All h3 0 base cell indices in the tree
-    nodes: Box<[Option<Node>]>,
+    root: Box<[Option<Node>]>,
 }
 
 impl HexSet {
@@ -74,7 +74,7 @@ impl HexSet {
     /// H3 cells.
     pub fn new() -> Self {
         Self {
-            nodes: vec![None; 122].into_boxed_slice(),
+            root: vec![None; 122].into_boxed_slice(),
         }
     }
 
@@ -85,7 +85,7 @@ impl HexSet {
     /// significantly smaller than the number of source cells used to
     /// create the set.
     pub fn len(&self) -> usize {
-        self.nodes.iter().flatten().map(|node| node.len()).sum()
+        self.root.iter().flatten().map(|node| node.len()).sum()
     }
 
     /// Returns `true` if the set contains no cells.
@@ -97,12 +97,12 @@ impl HexSet {
     pub fn insert(&mut self, hex: H3Cell) {
         let base_cell = base(&hex);
         let digits = Digits::new(hex);
-        match self.nodes[base_cell as usize].as_mut() {
+        match self.root[base_cell as usize].as_mut() {
             Some(node) => node.insert(digits),
             None => {
                 let mut node = Node::new();
                 node.insert(digits);
-                self.nodes[base_cell as usize] = Some(node);
+                self.root[base_cell as usize] = Some(node);
             }
         }
     }
@@ -120,7 +120,7 @@ impl HexSet {
     ///    hex due to 1 or 2.
     pub fn contains(&self, hex: &H3Cell) -> bool {
         let base_cell = base(hex);
-        match self.nodes[base_cell as usize].as_ref() {
+        match self.root[base_cell as usize].as_ref() {
             Some(node) => {
                 let digits = Digits::new(*hex);
                 node.contains(digits)
@@ -136,7 +136,7 @@ impl HexSet {
     pub fn mem_size(&self) -> usize {
         size_of::<Self>()
             + self
-                .nodes
+                .root
                 .iter()
                 .flatten()
                 .map(|n| n.mem_size())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,17 @@ impl HexSet {
         }
     }
 
+    /// Constructs a new, empty `HexSet`.
+    ///
+    /// Incurs a single heap allocation to store all 122 resolution-0
+    /// H3 cells.
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            root: vec![None; 122].into_boxed_slice(),
+            arena: NodeArena::with_capacity(cap),
+        }
+    }
+
     /// Returns the number of H3 cells in the set.
     ///
     /// This method only considers complete, or leaf, hexagons in the
@@ -311,6 +322,13 @@ impl NodeArena {
     fn new() -> Self {
         Self {
             nodes: Vec::new(),
+            free: Vec::new(),
+        }
+    }
+
+    fn with_capacity(cap: usize) -> Self {
+        Self {
+            nodes: Vec::with_capacity(cap),
             free: Vec::new(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ use std::{
 
 /// An efficient way to represent any portion(s) of Earth as a set of
 /// `H3` hexagons.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 #[cfg_attr(
     feature = "serde-support",
     derive(serde::Serialize, serde::Deserialize)
@@ -155,6 +155,11 @@ impl HexSet {
         }
     }
 
+    /// Returns an iterator over all cells in this set.
+    pub fn cells(&self) -> impl IntoIterator<Item = H3Cell> {
+        [H3Cell::new(577164439745200127)]
+    }
+
     /// Returns the current memory use of this set.
     ///
     /// Note: The actual total may be higher than reported due to
@@ -196,7 +201,7 @@ impl<'a> FromIterator<&'a H3Cell> for HexSet {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 #[cfg_attr(
     feature = "serde-support",
     derive(serde::Serialize, serde::Deserialize)
@@ -308,7 +313,7 @@ impl DerefMut for Node {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 #[cfg_attr(
     feature = "serde-support",
     derive(serde::Serialize, serde::Deserialize)
@@ -435,16 +440,4 @@ mod tests {
             assert_eq!(&&digits, ref_digits);
         }
     }
-
-    // #[test]
-    // fn test_mem_size() {
-    //     // Sanity check that `Option<Node>` behaves the same as
-    //     // `Option<Box<[Option<Node>; 7]>>` in that it uses `NULL` to
-    //     // represent the `None` variant.
-    //     assert_eq!(size_of::<Option<Node>>(), size_of::<*const ()>());
-    //     assert_eq!(
-    //         size_of::<Option<Node>>(),
-    //         size_of::<Option<Box<[Option<Node>; 7]>>>()
-    //     );
-    // }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -129,7 +129,10 @@ fn test_compaction() {
         from_indicies(regions::nocompact::US915);
     let gulf_of_mexico = H3Cell::from_coordinate(&coord! {x: -83.101920, y: 28.128096}, 0).unwrap();
     assert_eq!(us915_tree.len(), us915_nocompact_tree.len());
-    assert!(us915_tree == us915_nocompact_tree);
+    assert!(us915_tree
+        .cells()
+        .into_iter()
+        .eq(us915_nocompact_tree.cells().into_iter()));
     assert!(us915_nocompact_tree.len() < us915_nocompact_cells.len());
     assert!(us915_nocompact_cells
         .iter()


### PR DESCRIPTION
This is an experimental PR to improve HexSet creation. It appears to halve the time to build up very large sets at the expense of up about slowing down `contains()` by about 20%. I originally thought this approach could take advance of cache locality to also improve contains, so this PR may be dead in the water.