### PR TITLE
Make Cell/Index fns const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ default = []
 serde-support = ["serde"]
 
 [dependencies]
-bitfield = "0"
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = "1"
 


### PR DESCRIPTION
I can foresee the need to construct `Cell`s at compile time, and there's no overhead. Additionally, gets rid of the bitfield dep since it isn't compatible with const setters and getters