### PR TITLE
Derive node cell values when needed

### DIFF
--- a/src/hex_tree_map.rs
+++ b/src/hex_tree_map.rs
@@ -176,12 +176,12 @@ impl<V, C> HexTreeMap<V, C> {
 
     /// Returns a reference to the value corresponding to the given
     /// hex or one of its parents.
-    pub fn get(&self, hex: Cell) -> Option<&V> {
+    pub fn get(&self, hex: Cell) -> Option<(Cell, &V)> {
         let base_cell = hex.base();
         match self.nodes[base_cell as usize].as_ref() {
             Some(node) => {
                 let digits = Digits::new(hex);
-                node.get(digits)
+                node.get(hex, digits)
             }
             None => None,
         }

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -34,12 +34,12 @@ impl<'a, V> Iterator for Iter<'a, V> {
         }
         while let Some(curr) = self.curr {
             match curr.as_ref() {
-                Node::Parent(_, children) => {
+                Node::Parent(children) => {
                     let mut iter = children.iter().flatten();
                     self.curr = iter.next();
                     self.stack.push(iter);
                 }
-                Node::Leaf(cell, value) => {
+                Node::Leaf(value) => {
                     self.curr = None;
                     return Some((cell, value));
                 }
@@ -83,12 +83,12 @@ impl<'a, V> Iterator for IterMut<'a, V> {
         }
         while let Some(curr) = self.curr.take() {
             match curr.as_mut() {
-                Node::Parent(_, children) => {
+                Node::Parent(children) => {
                     let mut iter = children.iter_mut().flatten();
                     self.curr = iter.next();
                     self.stack.push(iter);
                 }
-                Node::Leaf(cell, value) => {
+                Node::Leaf(value) => {
                     self.curr = None;
                     return Some((cell, value));
                 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -14,26 +14,26 @@ use crate::{compaction::Compactor, digits::Digits, Cell};
 )]
 #[repr(align(64))]
 pub(crate) enum Node<V> {
-    Parent(Cell, [Option<Box<Node<V>>>; 7]),
-    Leaf(Cell, V),
+    Parent([Option<Box<Node<V>>>; 7]),
+    Leaf(V),
 }
 
 impl<V> Node<V> {
-    pub(crate) fn new(hex: Cell) -> Self {
-        Self::Parent(hex, [None, None, None, None, None, None, None])
+    pub(crate) fn new() -> Self {
+        Self::Parent([None, None, None, None, None, None, None])
     }
 
     pub(crate) fn len(&self) -> usize {
         match self {
-            Self::Leaf(_, _) => 1,
-            Self::Parent(_, children) => children.iter().flatten().map(|child| child.len()).sum(),
+            Self::Leaf(_) => 1,
+            Self::Parent(children) => children.iter().flatten().map(|child| child.len()).sum(),
         }
     }
 
     pub(crate) fn insert<C>(
         &mut self,
-        hex: Cell,
         res: u8,
+        hex: Cell,
         mut digits: Digits,
         value: V,
         compactor: &mut C,
@@ -41,25 +41,17 @@ impl<V> Node<V> {
         C: Compactor<V>,
     {
         match digits.next() {
-            None => {
-                debug_assert_eq!(res, hex.res());
-                *self = Self::Leaf(hex, value)
-            }
+            None => *self = Self::Leaf(value),
             Some(digit) => match self {
-                Self::Leaf(leaf_hex, _) => {
-                    debug_assert_eq!(*leaf_hex, hex.to_parent(res).unwrap());
+                Self::Leaf(_) => {
                     return;
                 }
-                Self::Parent(parent_hex, children) => {
-                    debug_assert_eq!(parent_hex.res(), res);
+                Self::Parent(children) => {
                     match children[digit as usize].as_mut() {
-                        Some(node) => node.insert(hex, res + 1, digits, value, compactor),
+                        Some(node) => node.insert(res + 1, hex, digits, value, compactor),
                         None => {
-                            let mut node = Node::new(
-                                hex.to_parent(res + 1)
-                                    .expect("Digits returned Some, promotion should work"),
-                            );
-                            node.insert(hex, res + 1, digits, value, compactor);
+                            let mut node = Node::new();
+                            node.insert(res + 1, hex, digits, value, compactor);
                             children[digit as usize] = Some(Box::new(node));
                         }
                     };
@@ -73,11 +65,10 @@ impl<V> Node<V> {
     where
         C: Compactor<V>,
     {
-        if let Self::Parent(hex, children) = self {
-            debug_assert_eq!(hex.res(), res);
+        if let Self::Parent(children) = self {
             if children
                 .iter()
-                .any(|n| matches!(n.as_ref().map(|n| n.as_ref()), Some(Self::Parent(_, _))))
+                .any(|n| matches!(n.as_ref().map(|n| n.as_ref()), Some(Self::Parent(_))))
             {
                 return;
             }
@@ -86,14 +77,14 @@ impl<V> Node<V> {
                 *v = n.as_ref().map(|n| n.as_ref()).and_then(Node::value);
             }
             if let Some(value) = compactor.compact(res, arr) {
-                *self = Self::Leaf(*hex, value)
+                *self = Self::Leaf(value)
             }
         };
     }
 
     pub(crate) fn value(&self) -> Option<&V> {
         match self {
-            Self::Leaf(_, value) => Some(value),
+            Self::Leaf(value) => Some(value),
             _ => None,
         }
     }
@@ -101,54 +92,53 @@ impl<V> Node<V> {
     #[inline]
     pub(crate) fn contains(&self, mut digits: Digits) -> bool {
         match (digits.next(), self) {
-            (_, Self::Leaf(_, _)) => true,
-            (Some(digit), Self::Parent(_, children)) => {
-                // TODO check if this node is "full"
-                match &children.as_slice()[digit as usize] {
-                    Some(node) => node.contains(digits),
-                    None => false,
-                }
-            }
+            (_, Self::Leaf(_)) => true,
+            (Some(digit), Self::Parent(children)) => match &children.as_slice()[digit as usize] {
+                Some(node) => node.contains(digits),
+                None => false,
+            },
             // No digits left, but `self` isn't full, so this hex
             // can't fully contain the target.
-            (None, Self::Parent(_, _)) => false,
+            (None, Self::Parent(_)) => false,
         }
     }
 
-    pub(crate) fn get(&self, mut digits: Digits) -> Option<&V> {
-        if let Self::Leaf(_, val) = self {
-            return Some(val);
+    pub(crate) fn get(&self, res: u8, cell: Cell, mut digits: Digits) -> Option<(Cell, &V)> {
+        if let Self::Leaf(val) = self {
+            return Some((cell.to_parent(res).unwrap(), val));
         }
-
         match (digits.next(), self) {
-            (_, Self::Leaf(_, _)) => unreachable!(),
-            (Some(digit), Self::Parent(_, children)) => {
-                match &children.as_slice()[digit as usize] {
-                    Some(node) => node.get(digits),
-                    None => None,
-                }
-            }
+            (_, Self::Leaf(_)) => unreachable!(),
+            (Some(digit), Self::Parent(children)) => match &children.as_slice()[digit as usize] {
+                Some(node) => node.get(res + 1, cell, digits),
+                None => None,
+            },
             // No digits left, but `self` isn't full, so this hex
             // can't fully contain the target.
-            (None, Self::Parent(_, _)) => None,
+            (None, Self::Parent(_)) => None,
         }
     }
 
-    pub(crate) fn get_mut(&mut self, mut digits: Digits) -> Option<&mut V> {
-        if let Self::Leaf(_, val) = self {
-            return Some(val);
+    pub(crate) fn get_mut(
+        &mut self,
+        res: u8,
+        cell: Cell,
+        mut digits: Digits,
+    ) -> Option<(Cell, &mut V)> {
+        if let Self::Leaf(val) = self {
+            return Some((cell.to_parent(res).unwrap(), val));
         }
         match (digits.next(), self) {
-            (_, Self::Leaf(_, _)) => unreachable!(),
-            (Some(digit), Self::Parent(_, children)) => {
+            (_, Self::Leaf(_)) => unreachable!(),
+            (Some(digit), Self::Parent(children)) => {
                 match &mut children.as_mut_slice()[digit as usize] {
-                    Some(node) => node.get_mut(digits),
+                    Some(node) => node.get_mut(res + 1, cell, digits),
                     None => None,
                 }
             }
             // No digits left, but `self` isn't full, so this hex
             // can't fully contain the target.
-            (None, Self::Parent(_, _)) => None,
+            (None, Self::Parent(_)) => None,
         }
     }
 }


### PR DESCRIPTION
This _may_ improve insertion throughout, while there’s a non zero chance it will hurt lookup speed.  But it’s certainly going to reduce memory usage by removing 8 bytes from every node. 