### PR TITLE
Derive H3 Cells when walking trees (do not store them)

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -170,7 +170,7 @@ fn map_iteration(c: &mut Criterion) {
 
     group.bench_function("collect to vec", |b| {
         b.iter(|| {
-            let out: Vec<(&Cell, &u32)> = map_precompacted.iter().collect();
+            let out: Vec<(Cell, &u32)> = map_precompacted.iter().collect();
             out
         })
     });
@@ -188,7 +188,7 @@ fn set_iteration(c: &mut Criterion) {
 
     group.bench_function("collect to vec", |b| {
         b.iter(|| {
-            let out: Vec<Cell> = set_precompacted.iter().map(|cv| *cv.0).collect();
+            let out: Vec<Cell> = set_precompacted.iter().map(|cv| cv.0).collect();
             out
         })
     });

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -24,6 +24,7 @@ impl Index {
     /// Returns this index's reserved bit.
     ///
     /// Must always be 0 to remain valid.
+    #[inline]
     pub const fn reserved(self) -> bool {
         self.0 >> 0x3F == 1
     }
@@ -35,6 +36,7 @@ impl Index {
     /// 2 - is an H3 Directed Edge (Cell A -> Cell B) index.
     /// 3 - is planned to be a bidirectional edge (Cell A <-> Cell B).
     /// 4 - is an H3 Vertex (i.e. a single vertex of an H3 Cell).
+    #[inline]
     pub const fn mode(self) -> u8 {
         (self.0 >> 0x3B) as u8 & 0b1111
     }
@@ -43,6 +45,7 @@ impl Index {
     ///
     /// Interpretation of this value depends on the mode bits' value.
     #[allow(dead_code)]
+    #[inline]
     pub const fn mode_dep(self) -> u8 {
         (self.0 >> 0x38) as u8 & 0b111
     }
@@ -51,6 +54,7 @@ impl Index {
     ///
     /// All values are valid, with 0 the coarsest resolution and 15
     /// the finest.
+    #[inline]
     pub const fn res(self) -> u8 {
         let res = (self.0 >> 0x34) as u8 & 0b1111;
         debug_assert!(res < 16);
@@ -63,6 +67,7 @@ impl Index {
     /// This function does not check `res` for validity, and any value
     /// for res over 15 is masked to 4 bits.
     #[must_use]
+    #[inline]
     pub const fn set_res(self, res: u8) -> Self {
         debug_assert!(res < 16);
         let mask = 0b1111 << 0x34;
@@ -74,6 +79,7 @@ impl Index {
     /// Returns this index's base, or resolution cell.
     ///
     /// There are 122 valid H3 base cells, in [0,122).
+    #[inline]
     pub const fn base(self) -> u8 {
         let base = (self.0 >> 0x2D) as u8 & 0b111_1111;
         debug_assert!(base < 122);
@@ -86,6 +92,7 @@ impl Index {
     /// This function does not check `base` for validity, and
     /// providing any value >121 will return an invalid index.
     #[must_use]
+    #[inline]
     pub const fn set_base(self, base: u8) -> Self {
         debug_assert!(base < 122);
         let cleared_of_base = self.0 & !(0b111_1111 << 0x2D);
@@ -94,6 +101,7 @@ impl Index {
     }
 
     /// Returns the 3 bit digit value at the provided `res`.
+    #[inline]
     pub const fn digit(self, res: u8) -> Option<u8> {
         debug_assert!(res < 16);
         debug_assert!(res > 0);
@@ -110,6 +118,7 @@ impl Index {
     /// This function does not check `res` nor `digit` for validity
     /// and can panic or return an invalid index.
     #[must_use]
+    #[inline]
     pub const fn set_digit(self, res: u8, digit: u8) -> Self {
         debug_assert!(digit < 8);
         debug_assert!(res > 0);
@@ -138,6 +147,7 @@ impl Cell {
     /// an H3 cell (mode 1 H3 index).
     ///
     /// [bit-representation]: https://h3geo.org/docs/core-library/h3Indexing/
+    #[inline]
     pub const fn from_raw(raw: u64) -> Result<Self> {
         let idx = Index(raw);
         if
@@ -155,6 +165,7 @@ impl Cell {
     }
 
     /// Returns the raw [u64] H3 index for this cell.
+    #[inline]
     pub const fn into_raw(self) -> u64 {
         self.0
     }
@@ -163,6 +174,7 @@ impl Cell {
     ///
     /// Returns Some if `res` is less-than or equal-to this cell's
     /// resolution, otherwise returns None.
+    #[inline]
     pub const fn to_parent(&self, res: u8) -> Option<Self> {
         match self.res() {
             v if v < res => None,
@@ -178,6 +190,7 @@ impl Cell {
     }
 
     /// Returns this cell's base (res-0 parent).
+    #[inline]
     pub const fn base(&self) -> u8 {
         let base = Index(self.0).base();
         debug_assert!(base < 122, "valid base indices are [0,122]");
@@ -185,6 +198,7 @@ impl Cell {
     }
 
     /// Returns this cell's resolution.
+    #[inline]
     pub const fn res(&self) -> u8 {
         Index(self.0).res()
     }

--- a/src/hex_tree_map.rs
+++ b/src/hex_tree_map.rs
@@ -97,10 +97,10 @@ impl<V, C: Compactor<V>> HexTreeMap<V, C> {
         let base_cell = hex.base();
         let digits = Digits::new(hex);
         match self.nodes[base_cell as usize].as_mut() {
-            Some(node) => node.insert(hex, 0_u8, digits, value, &mut self.compactor),
+            Some(node) => node.insert(0_u8, digits, value, &mut self.compactor),
             None => {
                 let mut node = Box::new(Node::new());
-                node.insert(hex, 0_u8, digits, value, &mut self.compactor);
+                node.insert(0_u8, digits, value, &mut self.compactor);
                 self.nodes[base_cell as usize] = Some(node);
             }
         }

--- a/src/hex_tree_map.rs
+++ b/src/hex_tree_map.rs
@@ -99,9 +99,7 @@ impl<V, C: Compactor<V>> HexTreeMap<V, C> {
         match self.nodes[base_cell as usize].as_mut() {
             Some(node) => node.insert(hex, 0_u8, digits, value, &mut self.compactor),
             None => {
-                let mut node = Box::new(Node::new(
-                    hex.to_parent(0).expect("any hex can be promoted to res 0"),
-                ));
+                let mut node = Box::new(Node::new());
                 node.insert(hex, 0_u8, digits, value, &mut self.compactor);
                 self.nodes[base_cell as usize] = Some(node);
             }

--- a/src/hex_tree_map.rs
+++ b/src/hex_tree_map.rs
@@ -212,13 +212,13 @@ impl<V, C> HexTreeMap<V, C> {
     }
 
     /// An iterator visiting all cell-value pairs in arbitrary order.
-    pub fn iter(&self) -> impl Iterator<Item = (&Cell, &V)> {
+    pub fn iter(&self) -> impl Iterator<Item = (Cell, &V)> {
         crate::iteration::Iter::new(&self.nodes)
     }
 
     /// An iterator visiting all cell-value pairs in arbitrary order
     /// with mutable references to the values.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Cell, &mut V)> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (Cell, &mut V)> {
         crate::iteration::IterMut::new(&mut self.nodes)
     }
 }

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -1,11 +1,10 @@
 use crate::{cell::CellStack, node::Node, Cell};
-use std::iter::{Enumerate, Flatten, Map};
+use std::iter::{Enumerate, FlatMap};
 
-type NodeStackIter<'a, V> = Flatten<
-    Map<
-        Enumerate<std::slice::Iter<'a, Option<Box<Node<V>>>>>,
-        fn((usize, &'a Option<Box<Node<V>>>)) -> Option<(usize, &'a Box<Node<V>>)>,
-    >,
+type NodeStackIter<'a, V> = FlatMap<
+    Enumerate<std::slice::Iter<'a, Option<Box<Node<V>>>>>,
+    Option<(usize, &'a Box<Node<V>>)>,
+    fn((usize, &'a Option<Box<Node<V>>>)) -> Option<(usize, &'a Box<Node<V>>)>,
 >;
 
 fn make_node_stack_iter<'a, V>(nodes: &'a [Option<Box<Node<V>>>]) -> NodeStackIter<'a, V> {
@@ -18,12 +17,10 @@ fn make_node_stack_iter<'a, V>(nodes: &'a [Option<Box<Node<V>>>]) -> NodeStackIt
         }
     }
 
-    #[allow(clippy::map_flatten)]
     nodes
         .iter()
         .enumerate()
-        .map(map_fn as fn((_, &'a Option<Box<Node<V>>>)) -> Option<(_, &'a Box<Node<V>>)>)
-        .flatten()
+        .flat_map(map_fn as fn((_, &'a Option<Box<Node<V>>>)) -> Option<(_, &'a Box<Node<V>>)>)
 }
 
 pub(crate) struct Iter<'a, V> {
@@ -95,11 +92,10 @@ impl<'a, V> Iterator for Iter<'a, V> {
     }
 }
 
-type NodeStackIterMut<'a, V> = Flatten<
-    Map<
-        Enumerate<std::slice::IterMut<'a, Option<Box<Node<V>>>>>,
-        fn((usize, &'a mut Option<Box<Node<V>>>)) -> Option<(usize, &'a mut Box<Node<V>>)>,
-    >,
+type NodeStackIterMut<'a, V> = FlatMap<
+    Enumerate<std::slice::IterMut<'a, Option<Box<Node<V>>>>>,
+    Option<(usize, &'a mut Box<Node<V>>)>,
+    fn((usize, &'a mut Option<Box<Node<V>>>)) -> Option<(usize, &'a mut Box<Node<V>>)>,
 >;
 
 fn make_node_stack_iter_mut<'a, V>(
@@ -116,15 +112,9 @@ fn make_node_stack_iter_mut<'a, V>(
         }
     }
 
-    #[allow(clippy::map_flatten)]
-    nodes
-        .iter_mut()
-        .enumerate()
-        .map(
-            map_fn_mut
-                as fn((_, &'a mut Option<Box<Node<V>>>)) -> Option<(_, &'a mut Box<Node<V>>)>,
-        )
-        .flatten()
+    nodes.iter_mut().enumerate().flat_map(
+        map_fn_mut as fn((_, &'a mut Option<Box<Node<V>>>)) -> Option<(_, &'a mut Box<Node<V>>)>,
+    )
 }
 
 pub(crate) struct IterMut<'a, V> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use crate::{compaction::Compactor, digits::Digits, Cell};
+use crate::{compaction::Compactor, digits::Digits};
 
 // TODO: storing indices in nodes is not necessary, since the index
 // can always be derived by the path through the tree to get to the
@@ -30,14 +30,8 @@ impl<V> Node<V> {
         }
     }
 
-    pub(crate) fn insert<C>(
-        &mut self,
-        hex: Cell,
-        res: u8,
-        mut digits: Digits,
-        value: V,
-        compactor: &mut C,
-    ) where
+    pub(crate) fn insert<C>(&mut self, res: u8, mut digits: Digits, value: V, compactor: &mut C)
+    where
         C: Compactor<V>,
     {
         match digits.next() {
@@ -48,10 +42,10 @@ impl<V> Node<V> {
                 }
                 Self::Parent(children) => {
                     match children[digit as usize].as_mut() {
-                        Some(node) => node.insert(hex, res + 1, digits, value, compactor),
+                        Some(node) => node.insert(res + 1, digits, value, compactor),
                         None => {
                             let mut node = Node::new();
-                            node.insert(hex, res + 1, digits, value, compactor);
+                            node.insert(res + 1, digits, value, compactor);
                             children[digit as usize] = Some(Box::new(node));
                         }
                     };

--- a/src/node.rs
+++ b/src/node.rs
@@ -14,19 +14,19 @@ use crate::{compaction::Compactor, digits::Digits, Cell};
 )]
 #[repr(align(64))]
 pub(crate) enum Node<V> {
-    Parent(Cell, [Option<Box<Node<V>>>; 7]),
-    Leaf(Cell, V),
+    Parent([Option<Box<Node<V>>>; 7]),
+    Leaf(V),
 }
 
 impl<V> Node<V> {
-    pub(crate) fn new(hex: Cell) -> Self {
-        Self::Parent(hex, [None, None, None, None, None, None, None])
+    pub(crate) fn new() -> Self {
+        Self::Parent([None, None, None, None, None, None, None])
     }
 
     pub(crate) fn len(&self) -> usize {
         match self {
-            Self::Leaf(_, _) => 1,
-            Self::Parent(_, children) => children.iter().flatten().map(|child| child.len()).sum(),
+            Self::Leaf(_) => 1,
+            Self::Parent(children) => children.iter().flatten().map(|child| child.len()).sum(),
         }
     }
 
@@ -41,24 +41,16 @@ impl<V> Node<V> {
         C: Compactor<V>,
     {
         match digits.next() {
-            None => {
-                debug_assert_eq!(res, hex.res());
-                *self = Self::Leaf(hex, value)
-            }
+            None => *self = Self::Leaf(value),
             Some(digit) => match self {
-                Self::Leaf(leaf_hex, _) => {
-                    debug_assert_eq!(*leaf_hex, hex.to_parent(res).unwrap());
+                Self::Leaf(_) => {
                     return;
                 }
-                Self::Parent(parent_hex, children) => {
-                    debug_assert_eq!(parent_hex.res(), res);
+                Self::Parent(children) => {
                     match children[digit as usize].as_mut() {
                         Some(node) => node.insert(hex, res + 1, digits, value, compactor),
                         None => {
-                            let mut node = Node::new(
-                                hex.to_parent(res + 1)
-                                    .expect("Digits returned Some, promotion should work"),
-                            );
+                            let mut node = Node::new();
                             node.insert(hex, res + 1, digits, value, compactor);
                             children[digit as usize] = Some(Box::new(node));
                         }
@@ -73,11 +65,10 @@ impl<V> Node<V> {
     where
         C: Compactor<V>,
     {
-        if let Self::Parent(hex, children) = self {
-            debug_assert_eq!(hex.res(), res);
+        if let Self::Parent(children) = self {
             if children
                 .iter()
-                .any(|n| matches!(n.as_ref().map(|n| n.as_ref()), Some(Self::Parent(_, _))))
+                .any(|n| matches!(n.as_ref().map(|n| n.as_ref()), Some(Self::Parent(_))))
             {
                 return;
             }
@@ -86,14 +77,14 @@ impl<V> Node<V> {
                 *v = n.as_ref().map(|n| n.as_ref()).and_then(Node::value);
             }
             if let Some(value) = compactor.compact(res, arr) {
-                *self = Self::Leaf(*hex, value)
+                *self = Self::Leaf(value)
             }
         };
     }
 
     pub(crate) fn value(&self) -> Option<&V> {
         match self {
-            Self::Leaf(_, value) => Some(value),
+            Self::Leaf(value) => Some(value),
             _ => None,
         }
     }
@@ -101,8 +92,8 @@ impl<V> Node<V> {
     #[inline]
     pub(crate) fn contains(&self, mut digits: Digits) -> bool {
         match (digits.next(), self) {
-            (_, Self::Leaf(_, _)) => true,
-            (Some(digit), Self::Parent(_, children)) => {
+            (_, Self::Leaf(_)) => true,
+            (Some(digit), Self::Parent(children)) => {
                 // TODO check if this node is "full"
                 match &children.as_slice()[digit as usize] {
                     Some(node) => node.contains(digits),
@@ -111,36 +102,34 @@ impl<V> Node<V> {
             }
             // No digits left, but `self` isn't full, so this hex
             // can't fully contain the target.
-            (None, Self::Parent(_, _)) => false,
+            (None, Self::Parent(_)) => false,
         }
     }
 
     pub(crate) fn get(&self, mut digits: Digits) -> Option<&V> {
-        if let Self::Leaf(_, val) = self {
+        if let Self::Leaf(val) = self {
             return Some(val);
         }
 
         match (digits.next(), self) {
-            (_, Self::Leaf(_, _)) => unreachable!(),
-            (Some(digit), Self::Parent(_, children)) => {
-                match &children.as_slice()[digit as usize] {
-                    Some(node) => node.get(digits),
-                    None => None,
-                }
-            }
+            (_, Self::Leaf(_)) => unreachable!(),
+            (Some(digit), Self::Parent(children)) => match &children.as_slice()[digit as usize] {
+                Some(node) => node.get(digits),
+                None => None,
+            },
             // No digits left, but `self` isn't full, so this hex
             // can't fully contain the target.
-            (None, Self::Parent(_, _)) => None,
+            (None, Self::Parent(_)) => None,
         }
     }
 
     pub(crate) fn get_mut(&mut self, mut digits: Digits) -> Option<&mut V> {
-        if let Self::Leaf(_, val) = self {
+        if let Self::Leaf(val) = self {
             return Some(val);
         }
         match (digits.next(), self) {
-            (_, Self::Leaf(_, _)) => unreachable!(),
-            (Some(digit), Self::Parent(_, children)) => {
+            (_, Self::Leaf(_)) => unreachable!(),
+            (Some(digit), Self::Parent(children)) => {
                 match &mut children.as_mut_slice()[digit as usize] {
                     Some(node) => node.get_mut(digits),
                     None => None,
@@ -148,7 +137,7 @@ impl<V> Node<V> {
             }
             // No digits left, but `self` isn't full, so this hex
             // can't fully contain the target.
-            (None, Self::Parent(_, _)) => None,
+            (None, Self::Parent(_)) => None,
         }
     }
 }


### PR DESCRIPTION
This PR adds a new type for building up and tearing down H3 cells: `CellStack`. It lets you push (add more resolution) and pop (reduce resolution) index digits from a cell. The end result is that we can remove Cells from Nodes, and save 8 bytes per node. This may have performance implications. We'll see, but I'm guessing that iteration will be slower and construction/lookup will be faster.

~~For the time being, Nodes are still storing their Cell values so that we can [assert] that the derived cell is correct.~~

[assert]:  https://github.com/JayKickliter/HexTree/pull/25/files#diff-ba416341d4f6e6281534be5b5232b42d89582ec245ad4f76f7ab292e0b2dd146R74

## API Breaking Changes

### Iteration

A hextree's iterator item type changes from `(&Cell, &Value)`  to `(Cell, &Value)`. This can likely be fixed, but there's some lifetime shenanigans involved as the Cell returned by the iterator no longer lives in the same inner Node as the value, thus it has a different lifetime. Additionally, I'm not sure there is much value in returning a `&Cell` instead of `Cell` as cells are `Copy`.