### PR TITLE
Lookup operations should return the cell along with the value

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ You can think of `HexTreeMap` vs. `HexTreeSet` as [`HashMap`] vs. [`HashSet`].
 
 The key feature of a hextree is that its keys (H3 cells) are
 hierarchical. For instance, if you previously inserted an entry for a
-low-res hex, but later query for a higher-res child hex, the tree
-returns the value for the lower res hex. Additionally, with
+low-res cell, but later query for a higher-res child cell, the tree
+returns the value for the lower res cell. Additionally, with
 [compaction], trees can automatically coalesce adjacent high-res
-hexagons into their parent hex. For very large regions, the compaction
+hexagons into their parent cell. For very large regions, the compaction
 process _can_ continue to lowest resolution cells (res-0), possibly
 removing millions of redundant cells from the tree. For example, a set
 of 4,795,661 res-7 cells representing North America coalesces [into a

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ The key feature of a hextree is that its keys (H3 cells) are
 hierarchical. For instance, if you previously inserted an entry for a
 low-res cell, but later query for a higher-res child cell, the tree
 returns the value for the lower res cell. Additionally, with
-[compaction], trees can automatically coalesce adjacent high-res
-hexagons into their parent cell. For very large regions, the compaction
-process _can_ continue to lowest resolution cells (res-0), possibly
-removing millions of redundant cells from the tree. For example, a set
-of 4,795,661 res-7 cells representing North America coalesces [into a
+[compaction], trees can automatically coalesce adjacent high-res cells
+into their parent cell. For very large regions, the compaction process
+_can_ continue to lowest resolution cells (res-0), possibly removing
+millions of redundant cells from the tree. For example, a set of
+4,795,661 res-7 cells representing North America coalesces [into a
 42,383 element `HexTreeSet`][us915].
 
 A hextree's internal structure exactly matches the semantics of an [H3

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -165,7 +165,7 @@ fn map_iteration(c: &mut Criterion) {
     let map_precompacted: HexTreeMap<u32> = COMPACT_US915_INDICES
         .iter()
         .map(|&idx| Cell::try_from(idx).unwrap())
-        .zip((0..).into_iter())
+        .zip(0..)
         .collect();
 
     group.bench_function("collect to vec", |b| {

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -191,7 +191,7 @@ impl Cell {
 
     /// Returns this cell's base (res-0 parent).
     #[inline]
-    pub const fn base(&self) -> u8 {
+    pub(crate) const fn base(&self) -> u8 {
         let base = Index(self.0).base();
         debug_assert!(base < 122, "valid base indices are [0,122]");
         base

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -17,14 +17,14 @@ pub enum Entry<'a, V, C> {
 /// A view into an occupied entry in a `HexTreeMap`. It is part of the
 /// [`Entry`] enum.
 pub struct OccupiedEntry<'a, V> {
-    pub(crate) hex: Cell,
+    pub(crate) target_cell: Cell,
     pub(crate) cell_value: (Cell, &'a mut V),
 }
 
 /// A view into a vacant entry in a `HexTreeMap`. It is part of the
 /// [`Entry`] enum.
 pub struct VacantEntry<'a, V, C> {
-    pub(crate) hex: Cell,
+    pub(crate) target_cell: Cell,
     pub(crate) map: &'a mut HexTreeMap<V, C>,
 }
 
@@ -62,12 +62,12 @@ where
     {
         match self {
             Entry::Occupied(OccupiedEntry {
-                hex,
+                target_cell,
                 cell_value: (cell, value),
             }) => {
                 f(cell, value);
                 Entry::Occupied(OccupiedEntry {
-                    hex,
+                    target_cell,
                     cell_value: (cell, value),
                 })
             }
@@ -96,11 +96,14 @@ where
     /// ```
     pub fn or_insert(self, default: V) -> (Cell, &'a mut V) {
         match self {
-            Entry::Occupied(OccupiedEntry { hex: _, cell_value }) => cell_value,
-            Entry::Vacant(VacantEntry { hex, map }) => {
-                map.insert(hex, default);
+            Entry::Occupied(OccupiedEntry {
+                target_cell: _,
+                cell_value,
+            }) => cell_value,
+            Entry::Vacant(VacantEntry { target_cell, map }) => {
+                map.insert(target_cell, default);
                 // We just inserted; unwrap is fine.
-                map.get_mut(hex).unwrap()
+                map.get_mut(target_cell).unwrap()
             }
         }
     }
@@ -129,11 +132,14 @@ where
         F: FnOnce() -> V,
     {
         match self {
-            Entry::Occupied(OccupiedEntry { hex: _, cell_value }) => cell_value,
-            Entry::Vacant(VacantEntry { hex, map }) => {
-                map.insert(hex, default());
+            Entry::Occupied(OccupiedEntry {
+                target_cell: _,
+                cell_value,
+            }) => cell_value,
+            Entry::Vacant(VacantEntry { target_cell, map }) => {
+                map.insert(target_cell, default());
                 // We just inserted; unwrap is fine.
-                map.get_mut(hex).unwrap()
+                map.get_mut(target_cell).unwrap()
             }
         }
     }
@@ -164,11 +170,14 @@ where
     /// ```
     pub fn or_default(self) -> (Cell, &'a mut V) {
         match self {
-            Entry::Occupied(OccupiedEntry { hex: _, cell_value }) => cell_value,
-            Entry::Vacant(VacantEntry { hex, map }) => {
-                map.insert(hex, Default::default());
+            Entry::Occupied(OccupiedEntry {
+                target_cell: _,
+                cell_value,
+            }) => cell_value,
+            Entry::Vacant(VacantEntry { target_cell, map }) => {
+                map.insert(target_cell, Default::default());
                 // We just inserted; unwrap is fine.
-                map.get_mut(hex).unwrap()
+                map.get_mut(target_cell).unwrap()
             }
         }
     }

--- a/src/hex_tree_map.rs
+++ b/src/hex_tree_map.rs
@@ -89,7 +89,7 @@ impl<V> HexTreeMap<V, NullCompactor> {
 }
 
 impl<V, C: Compactor<V>> HexTreeMap<V, C> {
-    /// Adds a hexagon/value pair to the set.
+    /// Adds a cell/value pair to the set.
     pub fn insert(&mut self, cell: Cell, value: V) {
         let base_cell = cell.base();
         let digits = Digits::new(cell);
@@ -134,7 +134,7 @@ impl<V, C> HexTreeMap<V, C> {
 
     /// Returns the number of H3 cells in the set.
     ///
-    /// This method only considers complete, or leaf, hexagons in the
+    /// This method only considers complete, or leaf, cells in the
     /// set. Due to automatic compaction, this number may be
     /// significantly smaller than the number of source cells used to
     /// create the set.
@@ -154,7 +154,7 @@ impl<V, C> HexTreeMap<V, C> {
     ///
     /// 1. There was an earlier [insert][Self::insert] call with
     ///    precisely this target cell.
-    /// 2. Several previously inserted hexagons coalesced into
+    /// 2. Several previously inserted cells coalesced into
     ///    precisely this target cell.
     /// 3. The set contains a complete (leaf) parent of this target
     ///    cell due to 1 or 2.
@@ -173,7 +173,7 @@ impl<V, C> HexTreeMap<V, C> {
     /// target cell or one of its parents.
     ///
     /// Note that this method also returns a Cell, which may be a
-    /// parent of the target hex provided.
+    /// parent of the target cell provided.
     pub fn get(&self, cell: Cell) -> Option<(Cell, &V)> {
         let base_cell = cell.base();
         match self.nodes[base_cell as usize].as_ref() {
@@ -189,7 +189,7 @@ impl<V, C> HexTreeMap<V, C> {
     /// given target cell or one of its parents.
     ///
     /// Note that this method also returns a Cell, which may be a
-    /// parent of the target hex provided.
+    /// parent of the target cell provided.
     pub fn get_mut(&mut self, cell: Cell) -> Option<(Cell, &mut V)> {
         let base_cell = cell.base();
         match self.nodes[base_cell as usize].as_mut() {

--- a/src/hex_tree_map.rs
+++ b/src/hex_tree_map.rs
@@ -97,10 +97,10 @@ impl<V, C: Compactor<V>> HexTreeMap<V, C> {
         let base_cell = hex.base();
         let digits = Digits::new(hex);
         match self.nodes[base_cell as usize].as_mut() {
-            Some(node) => node.insert(0_u8, digits, value, &mut self.compactor),
+            Some(node) => node.insert(hex, 0_u8, digits, value, &mut self.compactor),
             None => {
                 let mut node = Box::new(Node::new());
-                node.insert(0_u8, digits, value, &mut self.compactor);
+                node.insert(hex, 0_u8, digits, value, &mut self.compactor);
                 self.nodes[base_cell as usize] = Some(node);
             }
         }

--- a/src/hex_tree_set.rs
+++ b/src/hex_tree_set.rs
@@ -16,15 +16,11 @@ use std::iter::FromIterator;
 /// Let's create a HexTreeSet for Monaco as visualized in the map
 ///
 /// ```
-/// # use h3ron::Error;
-/// #
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use geo_types::coord;
 /// use hextree::{Cell, HexTreeSet};
-/// use h3ron::H3Cell;
 /// #
 /// #    use byteorder::{LittleEndian as LE, ReadBytesExt};
-/// #    use h3ron::{Index as H3Index, FromH3Index};
 /// #    let idx_bytes = include_bytes!("../assets//monaco.res12.h3idx");
 /// #    let rdr = &mut idx_bytes.as_slice();
 /// #    let mut cells = Vec::new();
@@ -37,11 +33,13 @@ use std::iter::FromIterator;
 ///
 /// // You can see in the map above that our set covers Point 1 (green
 /// // check) but not Point 2 (red x), let's test that.
-/// let point_1 = H3Cell::from_coordinate(coord! {x: 7.42418, y: 43.73631}, 12)?;
-/// let point_2 = H3Cell::from_coordinate(coord! {x: 7.42855, y: 43.73008}, 12)?;
+/// // Lat/lon 43.73631, 7.42418 @ res 12
+/// let point_1 = Cell::from_raw(0x8c3969a41da15ff)?;
+/// // Lat/lon 43.73008, 7.42855 @ res 12
+/// let point_2 = Cell::from_raw(0x8c3969a415065ff)?;
 ///
-/// assert!(monaco.contains(Cell::from_raw(*point_1)?));
-/// assert!(!monaco.contains(Cell::from_raw(*point_2)?));
+/// assert!(monaco.contains(point_1));
+/// assert!(!monaco.contains(point_2));
 ///
 /// #     Ok(())
 /// # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@
 //!
 //! The key feature of a hextree is that its keys (H3 cells) are
 //! hierarchical. For instance, if you previously inserted an entry
-//! for a low-res hex, but later query for a higher-res child hex, the
-//! tree returns the value for the lower res hex. Additionally, with
+//! for a low-res cell, but later query for a higher-res child cell, the
+//! tree returns the value for the lower res cell. Additionally, with
 //! [compaction], trees can automatically coalesce adjacent high-res
-//! hexagons into their parent hex. For every large regions, the
+//! hexagons into their parent cell. For every large regions, the
 //! compaction process _can_ continue to lowest resolution cells
 //! (res-0), possibly removing millions of redundant cells from the
 //! tree. For example, a set of 4,795,661 res-7 cells representing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,28 +1,30 @@
 #![deny(unsafe_code, missing_docs, rustdoc::broken_intra_doc_links)]
 
-//! hextree provides tree structures that represent geographic regions with H3 cells.
+//! hextree provides tree structures that represent geographic regions
+//! with H3 cells.
 //!
 //! The primary structures are:
-//! - [`HexTreeMap`][crate::HexTreeMap]: an H3Cell-to-value map.
-//! - [`HexTreeSet`][crate::HexTreeSet]: an H3Cell set for hit-testing.
+//! - [`HexTreeMap`][crate::HexTreeMap]: an Cell-to-value map.
+//! - [`HexTreeSet`][crate::HexTreeSet]: a Cell set for hit-testing.
 //!
 //! You can think of `HexTreeMap` vs. `HexTreeSet` as [`HashMap`] vs. [`HashSet`].
 //!
 //! For the rest of the documentation, we will use hextree to refer to
 //! the general data structure.
 //!
-//! ## How is this different from `HashMap<H3Cell, V>`?
+//! ## How is this different from `HashMap<Cell, V>`?
 //!
 //! The key feature of a hextree is that its keys (H3 cells) are
 //! hierarchical. For instance, if you previously inserted an entry
-//! for a low-res cell, but later query for a higher-res child cell, the
-//! tree returns the value for the lower res cell. Additionally, with
-//! [compaction], trees can automatically coalesce adjacent high-res
-//! hexagons into their parent cell. For every large regions, the
-//! compaction process _can_ continue to lowest resolution cells
+//! for a low-res cell, but later query for a higher-res child cell,
+//! the tree returns the value for the lower res cell. Additionally,
+//! with [compaction], trees can automatically coalesce adjacent
+//! high-res cells into their parent cell. For very large regions,
+//! the compaction process _can_ continue to lowest resolution cells
 //! (res-0), possibly removing millions of redundant cells from the
 //! tree. For example, a set of 4,795,661 res-7 cells representing
-//! North America coalesces [into a 42,383 element `HexTreeSet`][us915].
+//! North America coalesces [into a 42,383 element
+//! `HexTreeSet`][us915].
 //!
 //! A hextree's internal structure exactly matches the semantics of an
 //! [H3 cell]. The root of the tree has 122 resolution-0 nodes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@
 //! for a low-res cell, but later query for a higher-res child cell,
 //! the tree returns the value for the lower res cell. Additionally,
 //! with [compaction], trees can automatically coalesce adjacent
-//! high-res cells into their parent cell. For very large regions,
-//! the compaction process _can_ continue to lowest resolution cells
+//! high-res cells into their parent cell. For very large regions, the
+//! compaction process _can_ continue to lowest resolution cells
 //! (res-0), possibly removing millions of redundant cells from the
 //! tree. For example, a set of 4,795,661 res-7 cells representing
 //! North America coalesces [into a 42,383 element

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,7 +5,7 @@ use crate::{compaction::Compactor, digits::Digits, Cell};
 // node. That said, storing the index doesn't impose much lookup
 // overhead.
 //
-// The benefit of storing indices is vastly simpler Hex+Value
+// The benefit of storing indices is vastly simpler Cell+Value
 // iteration of a tree.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(
@@ -100,7 +100,7 @@ impl<V> Node<V> {
                     None => false,
                 }
             }
-            // No digits left, but `self` isn't full, so this hex
+            // No digits left, but `self` isn't full, so this cell
             // can't fully contain the target.
             (None, Self::Parent(_)) => false,
         }
@@ -116,7 +116,7 @@ impl<V> Node<V> {
                 Some(node) => node.get(res + 1, cell, digits),
                 None => None,
             },
-            // No digits left, but `self` isn't full, so this hex
+            // No digits left, but `self` isn't full, so this cell
             // can't fully contain the target.
             (None, Self::Parent(_)) => None,
         }
@@ -139,7 +139,7 @@ impl<V> Node<V> {
                     None => None,
                 }
             }
-            // No digits left, but `self` isn't full, so this hex
+            // No digits left, but `self` isn't full, so this cell
             // can't fully contain the target.
             (None, Self::Parent(_)) => None,
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -80,9 +80,13 @@ fn mono_map() {
     }
 
     for (name, cells) in regions.iter() {
-        assert!(cells
-            .iter()
-            .all(|c| monomap.get(Cell::try_from(*c).unwrap()) == Some(&name)));
+        assert!(cells.iter().map(|c| Cell::try_from(*c).unwrap()).all(|c| {
+            if let Some((cell, val)) = monomap.get(c) {
+                c.to_parent(cell.res()) == Some(cell) && val == &name
+            } else {
+                false
+            }
+        }));
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,7 +7,6 @@ use std::convert::TryFrom;
 /// Perform a linear search of `region` for `target` cell.
 fn naive_contains(region: &[Cell], target: Cell) -> bool {
     let promotions = (0..16)
-        .into_iter()
         .map(|res| {
             if res < target.res() {
                 target.to_parent(res).unwrap()


### PR DESCRIPTION
The actual cell a value belongs to may differ from what originally inserted due to compaction. The caller may need this information, and benchmarking shows little-to-no measurable perf hit in returning it.

Closes #26 
Closes #24 