### PR TITLE
Add Cell::is_related_to() function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hextree"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Jay Kickliter <jay@kickliter.com>", "Andrew Thompson <andrew@hijacked.us>"]
 categories = ["science", "data-structures"]
 edition = "2018"

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -202,6 +202,19 @@ impl Cell {
     pub const fn res(&self) -> u8 {
         Index(self.0).res()
     }
+
+    /// Returns true if `self` is related to `other`.
+    ///
+    /// "Related" can be any of the following:
+    /// - `self` == `other`
+    /// - `self` is a parent cell of `other`
+    /// - `other` is a parent cell of `self`
+    #[inline]
+    pub fn is_related_to(&self, other: &Self) -> bool {
+        let common_res = std::cmp::min(self.res(), other.res());
+        // Unwrap is fine. We already checked to the min common resolution.
+        self.to_parent(common_res).unwrap() == other.to_parent(common_res).unwrap()
+    }
 }
 
 impl TryFrom<u64> for Cell {


### PR DESCRIPTION
This is a very useful function for testing if two cells overlap.