### PR TITLE
Rename serde-support to serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 
 [features]
 default = []
-serde-support = ["serde"]
+serde = ["dep:serde"]
 
 [dependencies]
 serde = { version = "1", optional = true, features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the same as its corresponding H3 cell resolution.
 
 ## Features
 
-* **`serde-support`**: support for serialization via [serde].
+* **`serde`**: support for serialization via [serde].
 
 [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
 [`HashSet`]: https://doc.rust-lang.org/std/collections/struct.HashSet.html

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -14,7 +14,7 @@ use std::{convert::TryFrom, fmt};
 /// [index manipulation]: https://observablehq.com/@nrabinowitz/h3-index-bit-layout?collection=@nrabinowitz/h3
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde-support",
+    feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(transparent)
 )]
@@ -132,7 +132,7 @@ impl Index {
 /// [HexTreeMap][crate::HexTreeMap]'s key type.
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(
-    feature = "serde-support",
+    feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
     serde(transparent)
 )]

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -17,10 +17,7 @@ pub trait Compactor<V> {
 
 /// Does not perform any compaction.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde-support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NullCompactor;
 
 impl<V> Compactor<V> for NullCompactor {
@@ -31,10 +28,7 @@ impl<V> Compactor<V> for NullCompactor {
 
 /// Compacts when all children are complete.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde-support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCompactor;
 
 impl Compactor<()> for SetCompactor {
@@ -49,10 +43,7 @@ impl Compactor<()> for SetCompactor {
 
 /// Compacts when all children are complete and have the same value.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde-support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EqCompactor;
 
 impl<V: PartialEq + Clone> Compactor<V> for EqCompactor {

--- a/src/hex_tree_map.rs
+++ b/src/hex_tree_map.rs
@@ -61,10 +61,7 @@ use std::{cmp::PartialEq, iter::FromIterator};
 /// # }
 /// ```
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde-support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HexTreeMap<V, C = NullCompactor> {
     /// All h3 0 base cell indices in the tree
     nodes: Box<[Option<Box<Node<V>>>]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! ## Features
 //!
-//! * **`serde-support`**: support for serialization via [serde].
+//! * **`serde`**: support for serialization via [serde].
 //!
 //! [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
 //! [`HashSet`]: https://doc.rust-lang.org/std/collections/struct.HashSet.html

--- a/src/node.rs
+++ b/src/node.rs
@@ -8,10 +8,7 @@ use crate::{compaction::Compactor, digits::Digits, Cell};
 // The benefit of storing indices is vastly simpler Cell+Value
 // iteration of a tree.
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde-support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(align(64))]
 pub(crate) enum Node<V> {
     Parent([Option<Box<Node<V>>>; 7]),


### PR DESCRIPTION
Somehow I wasn't aware of the ability to use `"dep:"` when defining features.