### PR TITLE
Add subtree iteration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,10 @@ serde = { version = "1", optional = true, features = ["derive"] }
 [dev-dependencies]
 byteorder = "1"
 criterion = { version = "0.3", features = ["html_reports"] }
-h3ron = "0.15.1"
+geo = "0.26.0"
 geo-types = "0.7"
+h3o = { version = "0.4.0", features = ["geo"] }
+h3ron = "0.15.1"
 
 [dev-dependencies.h3-lorawan-regions]
 git = "https://github.com/JayKickliter/h3-lorawan-regions.git"

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -292,6 +292,12 @@ impl CellStack {
     }
 }
 
+impl From<Cell> for CellStack {
+    fn from(cell: Cell) -> CellStack {
+        CellStack(Some(cell))
+    }
+}
+
 impl fmt::Debug for Cell {
     /// [H3 Index](https://h3geo.org/docs/core-library/h3Indexing/):
     /// > The canonical string representation of an H3Index is the


### PR DESCRIPTION
This PR introduces `HexTreeMap::subtree_iter(cell)` which returns an iterator that visiting:

1. Nothing if the target `cell` isn't a parent or leaf in the map
2. Target `cell` only, if it is a leaf in the tree
3. Any cells in in the map which are descendants of `cell`

This subtree iteration is useful for aggregating, extracting, or folding over cell/value pairs in a hextree.