### PR TITLE
Implement get[_mut] on top of get_raw[_mut]

### DIFF
--- a/src/disktree/mod.rs
+++ b/src/disktree/mod.rs
@@ -57,8 +57,22 @@ mod tests {
             .unwrap();
         let monaco_disktree = DiskTreeMap::open(path).unwrap();
 
-        assert_eq!(monaco.get(point_2).unzip().1, None);
-        assert_eq!(monaco.get(point_1).unzip().1, Some(&Region::Monaco));
+        assert_eq!(monaco.get(point_2), None);
+        assert_eq!(
+            monaco.get(point_1),
+            Some((point_1.to_parent(9).unwrap(), &Region::Monaco))
+        );
+
+        let point_1_res8 = point_1.to_parent(8).unwrap();
+        assert!(matches!(
+            monaco.get_raw(point_1_res8),
+            Some((cell, crate::node::Node::Parent(_))) if cell == point_1_res8
+        ));
+
+        assert!(matches!(
+            monaco_disktree.get_raw(point_1_res8).unwrap(),
+            Some((cell, crate::disktree::node::Node::Parent(_))) if cell == point_1_res8
+        ));
 
         for (ht_cell, &ht_val) in monaco.iter() {
             let now = std::time::Instant::now();

--- a/src/disktree/node.rs
+++ b/src/disktree/node.rs
@@ -8,6 +8,7 @@ use std::{io::Read, mem::size_of, ops::Range};
 // Enough bytes to read node tag and 7 child dptrs.
 const NODE_BUF_SZ: usize = size_of::<u8>() + 7 * Dp::size();
 
+#[derive(Debug)]
 pub(crate) enum Node {
     // value_begin..value_end
     Leaf(Range<usize>),

--- a/src/hex_tree_map.rs
+++ b/src/hex_tree_map.rs
@@ -172,7 +172,16 @@ impl<V, C> HexTreeMap<V, C> {
     ///
     /// Note that this method also returns a Cell, which may be a
     /// parent of the target cell provided.
+    #[inline]
     pub fn get(&self, cell: Cell) -> Option<(Cell, &V)> {
+        match self.get_raw(cell) {
+            Some((cell, Node::Leaf(val))) => Some((cell, val)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn get_raw(&self, cell: Cell) -> Option<(Cell, &Node<V>)> {
         let base_cell = cell.base();
         match self.nodes[base_cell as usize].as_ref() {
             Some(node) => {
@@ -188,7 +197,16 @@ impl<V, C> HexTreeMap<V, C> {
     ///
     /// Note that this method also returns a Cell, which may be a
     /// parent of the target cell provided.
+    #[inline]
     pub fn get_mut(&mut self, cell: Cell) -> Option<(Cell, &mut V)> {
+        match self.get_raw_mut(cell) {
+            Some((cell, &mut Node::Leaf(ref mut val))) => Some((cell, val)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn get_raw_mut(&mut self, cell: Cell) -> Option<(Cell, &mut Node<V>)> {
         let base_cell = cell.base();
         match self.nodes[base_cell as usize].as_mut() {
             Some(node) => {
@@ -231,7 +249,7 @@ impl<V, C> HexTreeMap<V, C> {
         match self.nodes[base_cell as usize].as_ref() {
             Some(node) => {
                 let digits = Digits::new(cell);
-                match node.get_raw(0, cell, digits) {
+                match node.get(0, cell, digits) {
                     Some((cell, Node::Leaf(val))) => Some((cell, val))
                         .into_iter()
                         .chain(crate::iteration::Iter::empty()),
@@ -252,7 +270,7 @@ impl<V, C> HexTreeMap<V, C> {
         match self.nodes[base_cell as usize].as_mut() {
             Some(node) => {
                 let digits = Digits::new(cell);
-                match node.get_raw_mut(0, cell, digits) {
+                match node.get_mut(0, cell, digits) {
                     Some((cell, Node::Leaf(val))) => Some((cell, val))
                         .into_iter()
                         .chain(crate::iteration::IterMut::empty()),


### PR DESCRIPTION
This change us the first step of implementing DiskTreeMap::subtree_iter. The change is applied to HexTreeMap in order to keep similar patterns 